### PR TITLE
Clean repo to EVM-only version for ecommerce POC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules/
 artifacts/
 cache/
 
-wasm-contracts/*/target/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kontrak Token GOAT dan MEAT
 
-Repositori ini kini khusus memuat implementasi **EVM** untuk pengujian alur ecommerce. Versi CosmWasm telah dipisahkan.
+Repositori ini adalah versi **EVM-only** dari Moneter 5.0 untuk pengujian alur ecommerce.
 
 Repositori ini berisi dua token ERC20:
 

--- a/deploy-config/wasm-config.json
+++ b/deploy-config/wasm-config.json
@@ -1,7 +1,0 @@
-{
-  "rpc": "https://rpc.testnet.cosmos.network",
-  "chain_id": "testing-1",
-  "mnemonic_path": ".keys/deployer.txt",
-  "prefix": "cosmos",
-  "gas_price": "0.025uatom"
-}


### PR DESCRIPTION
## Summary
- remove deprecated wasm config
- clean `.gitignore`
- clarify README for EVM-only focus

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684cceaa665c8325bf6f21af7d550699