### PR TITLE
Clean repo to EVM only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 node_modules/
 artifacts/
 cache/
-
-wasm-contracts/*/target/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kontrak Token GOAT dan MEAT
 
-Repositori ini kini khusus memuat implementasi **EVM** untuk pengujian alur ecommerce. Versi CosmWasm telah dipisahkan.
+Repositori ini menyimpan versi **EVM-only** dari Moneter 5.0 untuk pengujian alur ecommerce.
 
 Repositori ini berisi dua token ERC20:
 

--- a/deploy-config/wasm-config.json
+++ b/deploy-config/wasm-config.json
@@ -1,7 +1,0 @@
-{
-  "rpc": "https://rpc.testnet.cosmos.network",
-  "chain_id": "testing-1",
-  "mnemonic_path": ".keys/deployer.txt",
-  "prefix": "cosmos",
-  "gas_price": "0.025uatom"
-}


### PR DESCRIPTION
## Summary
- remove leftover wasm config and ignore patterns
- trim README intro to clarify EVM-only focus
- ensure CI workflow keeps Hardhat tests only

## Testing
- `npm install --silent`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684d02986f4c8325913a5a1d47a7295e