### PR TITLE
Add burn invalid token tests

### DIFF
--- a/test/nftBurnMint.test.js
+++ b/test/nftBurnMint.test.js
@@ -114,6 +114,13 @@ describe("GoatNFT burn", function () {
     await expect(nft.burn(tokenId)).to.be.revertedWith("Not owner");
   });
 
+  it("reverts burn for nonexistent tokenId", async function () {
+    await expect(nft.connect(user).burn(999)).to.be.revertedWithCustomError(
+      nft,
+      "ERC721NonexistentToken"
+    );
+  });
+
   it("getGoatData cleared after burn", async function () {
     const tx = await nft.mint(user.address, 600, "clr", "Boer", 2022);
     const tokenId = (await tx.wait()).logs[0].args[2];

--- a/test/sapiNftBurn.test.js
+++ b/test/sapiNftBurn.test.js
@@ -54,6 +54,13 @@ describe("SapiNFT burn", function () {
     await expect(nft.burn(tokenId)).to.be.revertedWith("Not owner");
   });
 
+  it("reverts burn for nonexistent tokenId", async function () {
+    await expect(nft.connect(user).burn(999)).to.be.revertedWithCustomError(
+      nft,
+      "ERC721NonexistentToken"
+    );
+  });
+
   it("getSapiData cleared after burn", async function () {
     const tx = await nft.mint(user.address, 900, "id3", "Brahman", 2021);
     const tokenId = (await tx.wait()).logs[0].args[2];


### PR DESCRIPTION
## Summary
- add tests verifying GoatNFT and SapiNFT revert on non-existent token IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d05daa1d8832597cdab1966a5a1f0