### PR TITLE
Add test mode frontend and API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 artifacts/
+!artifacts/
+!artifacts/GoatNFT.json
+!artifacts/GoatToken.json
+!artifacts/SlaughterHandler.json
 cache/

--- a/README.md
+++ b/README.md
@@ -487,3 +487,23 @@ contract RedeemEngine is Ownable {
 
 Bukan sekadar dokumen, README ini menjadi "suara sistem" yang terus diperbarui
 dan dipertanggungjawabkan.
+
+## Test Mode Simulation
+
+Folder `frontend/src/pages` menyediakan antarmuka simulasi sederhana untuk membeli produk dan menebus hasil burn tanpa blockchain. API di bawah `pages/api` memvalidasi parameter berdasarkan ABI yang disimpan di folder `artifacts/` dan menghasilkan hash transaksi tiruan.
+
+### Menjalankan
+
+1. Install dependensi dan compile kontrak:
+   ```bash
+   npm install
+   npx hardhat compile
+   ```
+2. Jalankan Next.js dev server:
+   ```bash
+   cd frontend && npm install
+   npm run dev
+   ```
+
+Halaman `http://localhost:3000/shop` memungkinkan simulasi pembelian GOATMEAT atau BEEFMEAT. Setelah melakukan burn melalui API, halaman `http://localhost:3000/redeem` dapat digunakan untuk menebus menggunakan hash burn yang diberikan.
+

--- a/artifacts/GoatNFT.json
+++ b/artifacts/GoatNFT.json
@@ -1,0 +1,24 @@
+{
+  "abi": [
+    {
+      "name": "mint",
+      "type": "function",
+      "inputs": [
+        {"name": "to", "type": "address"},
+        {"name": "weight", "type": "uint256"},
+        {"name": "nfcId", "type": "string"},
+        {"name": "breed", "type": "string"},
+        {"name": "birthYear", "type": "uint256"}
+      ],
+      "outputs": [{"name": "", "type": "uint256"}],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "name": "burn",
+      "type": "function",
+      "inputs": [{"name": "tokenId", "type": "uint256"}],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    }
+  ]
+}

--- a/artifacts/GoatToken.json
+++ b/artifacts/GoatToken.json
@@ -1,0 +1,14 @@
+{
+  "abi": [
+    {
+      "name": "mint",
+      "type": "function",
+      "inputs": [
+        {"name": "to", "type": "address"},
+        {"name": "amount", "type": "uint256"}
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    }
+  ]
+}

--- a/artifacts/SlaughterHandler.json
+++ b/artifacts/SlaughterHandler.json
@@ -1,0 +1,11 @@
+{
+  "abi": [
+    {
+      "name": "processSlaughter",
+      "type": "function",
+      "inputs": [{"name": "tokenId", "type": "uint256"}],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    }
+  ]
+}

--- a/frontend/src/lib/abiHandler.ts
+++ b/frontend/src/lib/abiHandler.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import path from 'path';
+
+export function loadAbi(contractName: string) {
+  const artifactPath = path.resolve(process.cwd(), `artifacts/${contractName}.json`);
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
+  return artifact.abi;
+}
+
+export function validateFunctionCall(abi: any[], functionName: string, args: any[]): boolean {
+  const fn = abi.find((x: any) => x.name === functionName);
+  if (!fn) return false;
+  if ((fn.inputs?.length || 0) !== args.length) return false;
+  return true;
+}

--- a/frontend/src/pages/api/burn.ts
+++ b/frontend/src/pages/api/burn.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { tokenId } = req.body;
+  if (!tokenId || isNaN(Number(tokenId))) {
+    return res.status(400).json({ error: 'Invalid tokenId' });
+  }
+  return res.status(200).json({ status: 'Burned', burnHash: `burn-${tokenId}` });
+}

--- a/frontend/src/pages/api/redeem.ts
+++ b/frontend/src/pages/api/redeem.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { burnHash, address } = req.body;
+  if (!burnHash || !address) {
+    return res.status(400).json({ error: 'Missing data' });
+  }
+  return res.status(200).json({ redeemed: true, receipt: `receipt-${burnHash}` });
+}

--- a/frontend/src/pages/api/simulateTx.ts
+++ b/frontend/src/pages/api/simulateTx.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { loadAbi, validateFunctionCall } from '@/lib/abiHandler';
+import { generateTxHash } from '@/utils/txHash';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { contract, functionName, args } = req.body;
+  const abi = loadAbi(contract);
+
+  if (!validateFunctionCall(abi, functionName, args)) {
+    return res.status(400).json({ error: 'Invalid function call' });
+  }
+
+  const txHash = generateTxHash(functionName, args);
+  return res.status(200).json({ txHash });
+}

--- a/frontend/src/pages/redeem.tsx
+++ b/frontend/src/pages/redeem.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+export default function Redeem() {
+  const [burnHash, setBurnHash] = useState('');
+  const [address, setAddress] = useState('');
+  const [result, setResult] = useState('');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch('/api/redeem', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ burnHash, address })
+    });
+    const data = await res.json();
+    if (res.ok) setResult(data.receipt);
+    else setResult(data.error || 'error');
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Redeem</h1>
+      <form onSubmit={submit} className="space-y-2">
+        <input className="border p-2 w-full" value={burnHash} onChange={e => setBurnHash(e.target.value)} placeholder="burn hash" />
+        <input className="border p-2 w-full" value={address} onChange={e => setAddress(e.target.value)} placeholder="address" />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">Redeem</button>
+      </form>
+      {result && <p>{result}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/shop.tsx
+++ b/frontend/src/pages/shop.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+export default function Shop() {
+  const [message, setMessage] = useState('');
+
+  async function buy(product: string) {
+    const res = await fetch('/api/simulateTx', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contract: 'GoatToken',
+        functionName: 'mint',
+        args: [product]
+      })
+    });
+    const data = await res.json();
+    if (res.ok) setMessage(data.txHash);
+    else setMessage(data.error || 'error');
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Shop</h1>
+      <div className="space-x-4">
+        <button onClick={() => buy('GOATMEAT')} className="bg-green-600 text-white px-4 py-2 rounded">Buy Goat Meat</button>
+        <button onClick={() => buy('BEEFMEAT')} className="bg-red-600 text-white px-4 py-2 rounded">Buy Beef Meat</button>
+      </div>
+      {message && <p className="mt-4">{message}</p>}
+    </div>
+  );
+}

--- a/frontend/src/utils/txHash.ts
+++ b/frontend/src/utils/txHash.ts
@@ -1,0 +1,5 @@
+import { keccak256, toUtf8Bytes } from 'ethers';
+
+export function generateTxHash(fn: string, args: any[]) {
+  return keccak256(toUtf8Bytes(fn + JSON.stringify(args)));
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "rewrites": [
+    { "source": "/shop", "destination": "/shop" },
+    { "source": "/redeem", "destination": "/redeem" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add ABI loader and tx hash generator utilities
- include mock contract artifacts
- implement API routes for simulateTx, burn, and redeem
- add Tailwind-based shop and redeem pages
- document test mode simulation usage
- configure Vercel rewrites

## Testing
- `yes | npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_684d05daa1d8832597cdab1966a5a1f0